### PR TITLE
Support Fermi surface and dHvA frequencies calculation

### DIFF
--- a/src/aiidalab_qe_wannier90/model.py
+++ b/src/aiidalab_qe_wannier90/model.py
@@ -49,5 +49,3 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
         self.plot_wannier_functions = parameters.get('plot_wannier_functions', False)
         self.number_of_disproj_max = parameters.get('number_of_disproj_max', 15)
         self.number_of_disproj_min = parameters.get('number_of_disproj_min', 2)
-        self.compute_fermi_surface = parameters.get('compute_fermi_surface', False)
-        self.fermi_surface_kpoint_distance = parameters.get('fermi_surface_kpoint_distance', 0.04)

--- a/src/aiidalab_qe_wannier90/model.py
+++ b/src/aiidalab_qe_wannier90/model.py
@@ -23,6 +23,8 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
     projection_type = tl.Unicode(allow_none=True, default_value='atomic_projectors_qe')
     frozen_type = tl.Unicode(allow_none=True, default_value='fixed_plus_projectability')
     energy_window_input = tl.Float(allow_none=True, default_value=2.0)
+    compute_fermi_surface = tl.Bool(allow_none=True, default_value=False)
+    fermi_surface_kpoint_distance = tl.Float(allow_none=True, default_value=0.04)
 
     protocol = tl.Unicode(allow_none=True)
     electronic_type = tl.Unicode(allow_none=True)
@@ -38,6 +40,8 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
             'projection_type': self.projection_type,
             'frozen_type': self.frozen_type,
             'energy_window_input': self.energy_window_input,
+            'compute_fermi_surface': self.compute_fermi_surface,
+            'fermi_surface_kpoint_distance': self.fermi_surface_kpoint_distance,
         }
 
     def set_model_state(self, parameters: dict):
@@ -45,3 +49,5 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
         self.plot_wannier_functions = parameters.get('plot_wannier_functions', False)
         self.number_of_disproj_max = parameters.get('number_of_disproj_max', 15)
         self.number_of_disproj_min = parameters.get('number_of_disproj_min', 2)
+        self.compute_fermi_surface = parameters.get('compute_fermi_surface', False)
+        self.fermi_surface_kpoint_distance = parameters.get('fermi_surface_kpoint_distance', 0.04)

--- a/src/aiidalab_qe_wannier90/model.py
+++ b/src/aiidalab_qe_wannier90/model.py
@@ -25,12 +25,24 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
     energy_window_input = tl.Float(allow_none=True, default_value=2.0)
     compute_fermi_surface = tl.Bool(allow_none=True, default_value=False)
     fermi_surface_kpoint_distance = tl.Float(allow_none=True, default_value=0.04)
+    compute_dhva_frequencies = tl.Bool(allow_none=True, default_value=False)
+    # dHvA frequencies
+    dHvA_frequencies_parameters = tl.Dict(
+        allow_none=True,
+        default_value={
+            'starting_phi': 0.0,
+            'starting_theta': 90.0,
+            'ending_phi': 90.0,
+            'ending_theta': 90.0,
+            'num_rotation': 90,
+        }
+        )
 
     protocol = tl.Unicode(allow_none=True)
     electronic_type = tl.Unicode(allow_none=True)
 
     def get_model_state(self):
-        return {
+        state = {
             'exclude_semicore': self.exclude_semicore,
             'plot_wannier_functions': self.plot_wannier_functions,
             'retrieve_hamiltonian': self.retrieve_hamiltonian,
@@ -41,11 +53,21 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
             'frozen_type': self.frozen_type,
             'energy_window_input': self.energy_window_input,
             'compute_fermi_surface': self.compute_fermi_surface,
-            'fermi_surface_kpoint_distance': self.fermi_surface_kpoint_distance,
         }
+        if self.compute_fermi_surface:
+            state |= {
+                'fermi_surface_kpoint_distance': self.fermi_surface_kpoint_distance,
+                'compute_dhva_frequencies': self.compute_dhva_frequencies,
+            }
+            if self.compute_dhva_frequencies:
+                state |= {
+                    'dHvA_frequencies_parameters': self.dHvA_frequencies_parameters,
+                }
+        return state
 
     def set_model_state(self, parameters: dict):
         self.exclude_semicore = parameters.get('exclude_semicore', True)
         self.plot_wannier_functions = parameters.get('plot_wannier_functions', False)
         self.number_of_disproj_max = parameters.get('number_of_disproj_max', 15)
         self.number_of_disproj_min = parameters.get('number_of_disproj_min', 2)
+        self.compute_dhva_frequencies = parameters.get('compute_dhva_frequencies', False)

--- a/src/aiidalab_qe_wannier90/resources.py
+++ b/src/aiidalab_qe_wannier90/resources.py
@@ -42,6 +42,16 @@ class ResourceSettingsModel(PluginResourceSettingsModel):
                     description='Python code for isosurface calculation',
                     default_calc_job_plugin='pythonjob.pythonjob',
                 ),
+                'skeaf': CodeModel(
+                    name='skeaf_v1p3p0_r149',
+                    description='skeaf_v1p3p0_r149',
+                    default_calc_job_plugin='skeaf.skeaf',
+                ),
+                'wan2skeaf': CodeModel(
+                    name='wan2skeaf.jl',
+                    description='wan2skeaf.jl',
+                    default_calc_job_plugin='skeaf.wan2skeaf',
+                ),
 
             }
         )

--- a/src/aiidalab_qe_wannier90/result/model.py
+++ b/src/aiidalab_qe_wannier90/result/model.py
@@ -94,3 +94,13 @@ class Wannier90ResultsModel(ResultsModel):
         mesh_data = outputs.generate_isosurface.mesh_data
 
         return {'atoms': atoms, 'parameters': parameters, 'mesh_data': mesh_data}
+
+    def get_skeaf(self) -> dict:
+        outputs = self._get_child_outputs()
+        if 'skeaf' not in outputs:
+            return None
+        skeaf_results = {}
+        for band in outputs.skeaf.skeaf:
+            frequency = outputs.skeaf.skeaf[band].frequency
+            skeaf_results[band] = frequency
+        return skeaf_results

--- a/src/aiidalab_qe_wannier90/result/model.py
+++ b/src/aiidalab_qe_wannier90/result/model.py
@@ -2,7 +2,6 @@ from aiidalab_qe.common.panel import ResultsModel
 from aiida.common.extendeddicts import AttributeDict
 import traitlets as tl
 from aiida import orm
-import time
 
 class Wannier90ResultsModel(ResultsModel):
     title = 'Wannier functions'
@@ -14,6 +13,7 @@ class Wannier90ResultsModel(ResultsModel):
     omega_tots = tl.List(allow_none=True)
     im_re_ratio = tl.List(allow_none=True)
     wannier90_outputs = tl.Dict(allow_none=True)
+    retrieved = tl.Instance(orm.FolderData, allow_none=True)
 
     _this_process_label = 'QeAppWannier90BandsWorkChain'
 
@@ -26,6 +26,10 @@ class Wannier90ResultsModel(ResultsModel):
         # Wannier centers/spreads
         self.wannier_centers_spreads = self.get_wannier_centers_spreads(root)
         self.omega_is, self.omega_tots = self.get_omega(root)
+        if 'wannier90_plot' in root.outputs.wannier90.wannier90_bands:
+            self.retrieved = root.outputs.wannier90.wannier90_bands.wannier90_plot.retrieved
+        else:
+            self.retrieved = root.outputs.wannier90.wannier90_bands.wannier90_optimal.retrieved
 
     def get_omega(self, root):
         omega_is = []

--- a/src/aiidalab_qe_wannier90/result/result.py
+++ b/src/aiidalab_qe_wannier90/result/result.py
@@ -4,7 +4,7 @@ from aiidalab_qe.common.bands_pdos import BandsPdosModel, BandsPdosWidget
 from aiidalab_qe.common.panel import ResultsPanel
 import ipywidgets as ipw
 from .model import Wannier90ResultsModel
-from ..utils import create_download_link
+from .utils import create_download_link, plot_skeaf
 from table_widget import TableWidget
 import plotly.graph_objs as go
 import plotly.express as px
@@ -127,6 +127,10 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         ], layout=ipw.Layout(width='50%',
             margin='10px 0'))
 
+        # de Haas van Alphen (dHvA) frequencies
+        skeaf_data = self._model.get_skeaf() # skeaf_data is a dictionary {band: frequency_array}
+        self.plot_skeaf = plot_skeaf(skeaf_data)
+
         # Downloads section
         download_links = []
 
@@ -135,12 +139,12 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
                 # Create a download link for the .tb.dat file
                 temp_dir = self._model.retrieved
                 download_links.append(create_download_link(
-                    temp_dir, filename, description=f'Download {filename}'))
+                    temp_dir, filename, description=f'Download the tight-binding model {filename}'))
             elif filename.endswith('.bxsf'):
                 # Create a download link for the .bxsf file
                 temp_dir = self._model.retrieved
                 download_links.append(create_download_link(
-                    temp_dir, filename, description=f'Download {filename}'))
+                    temp_dir, filename, description=f'Download the Fermi surface {filename}'))
 
 
         # Arrange components in the panel
@@ -154,6 +158,11 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
                 wannier90_outputs_parameters,
                 ipw.HBox([self.plot_omega_is, self.plot_omega_tots]),
                 ipw.HBox([structure_viewer_section, table_section]),
+            ]),
+            ipw.VBox([
+                ipw.HTML('<h2>Fermi surface</h2>'),
+                ipw.HTML('<h3>de Haas van Alphen (dHva) frequencies</h3>'),
+                ipw.HBox([self.plot_skeaf,]),
             ]),
             ipw.VBox([
                 ipw.HTML('<h2>Download files</h2>'),

--- a/src/aiidalab_qe_wannier90/result/result.py
+++ b/src/aiidalab_qe_wannier90/result/result.py
@@ -4,6 +4,7 @@ from aiidalab_qe.common.bands_pdos import BandsPdosModel, BandsPdosWidget
 from aiidalab_qe.common.panel import ResultsPanel
 import ipywidgets as ipw
 from .model import Wannier90ResultsModel
+from ..utils import create_download_link
 from table_widget import TableWidget
 import plotly.graph_objs as go
 import plotly.express as px
@@ -126,7 +127,20 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         ], layout=ipw.Layout(width='50%',
             margin='10px 0'))
 
+        # Downloads section
+        download_links = []
 
+        for filename in self._model.retrieved.list_object_names():
+            if filename.endswith('_tb.dat'):
+                # Create a download link for the .tb.dat file
+                temp_dir = self._model.retrieved
+                download_links.append(create_download_link(
+                    temp_dir, filename, description=f'Download {filename}'))
+            elif filename.endswith('.bxsf'):
+                # Create a download link for the .bxsf file
+                temp_dir = self._model.retrieved
+                download_links.append(create_download_link(
+                    temp_dir, filename, description=f'Download {filename}'))
 
 
         # Arrange components in the panel
@@ -140,6 +154,10 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
                 wannier90_outputs_parameters,
                 ipw.HBox([self.plot_omega_is, self.plot_omega_tots]),
                 ipw.HBox([structure_viewer_section, table_section]),
+            ]),
+            ipw.VBox([
+                ipw.HTML('<h2>Download files</h2>'),
+                ipw.VBox(download_links),
             ]),
         ]
 

--- a/src/aiidalab_qe_wannier90/result/utils.py
+++ b/src/aiidalab_qe_wannier90/result/utils.py
@@ -1,0 +1,70 @@
+def create_download_link(obj, filename, description='Download'):
+    """Create a download link for a file in the AiiDA repository using a temporary directory."""
+    import base64
+    import shutil
+    import tempfile
+    import ipywidgets as ipw
+    from pathlib import Path
+    # Create a temporary directory to store the file
+    # Copy the file from the AiiDA repository to the temporary directory
+    with obj.as_path(filename) as source_path:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / filename
+            shutil.copy(source_path, tmp_path)
+
+            with open(tmp_path, 'rb') as f:
+                b64 = base64.b64encode(f.read()).decode()
+
+    # At this point, we no longer need the file; it's encoded.
+    payload = f'data:application/octet-stream;base64,{b64}'
+    html = f'<a download="{filename}" href="{payload}" target="_blank">{description}</a>'
+    return ipw.HTML(html)
+
+def plot_skeaf(skeaf_data):
+    """Plot the de Haas van Alphen (dHvA) frequencies from a Wannier90 workchain."""
+    import numpy as np
+    import plotly.express as px
+    import plotly.graph_objects as go
+
+    x = []         # theta values
+    y = []         # freq values
+    labels = []    # band names for color grouping
+    xlabel = 'Rotation step'
+
+    for band, array_node in skeaf_data.items():
+
+        phi = array_node.get_array('phi')
+        theta = array_node.get_array('theta')
+        freq = array_node.get_array('freq')
+
+        if len(np.unique(phi)) == 1:
+            if len(np.unique(theta)) > 1:
+                x.extend(theta)
+                y.extend(freq)
+                xlabel = '\u03B8, degrees'  # Greek letter theta
+        elif len(np.unique(theta)) == 1:
+            if len(np.unique(phi)) > 1:
+                x.extend(phi)
+                y.extend(freq)
+                xlabel = '\u03C6, degrees'  # Greek letter phi
+        elif len(np.unique(phi)) > 1 and len(np.unique(theta)) > 1:
+            # Combine phi and theta into a (N, 2) array of pairs
+            rotations = np.column_stack((phi, theta))
+
+            # Get unique rotations and the inverse indices
+            unique_rotations, rotation_indices = np.unique(rotations, axis=0, return_inverse=True)
+            x.extend(rotation_indices)  # Use indices as x values
+            y.extend(freq)
+        else:
+            # If neither phi nor theta has unique values, skip this band
+            continue
+
+        labels.extend([band] * len(x))  # repeat band name for each point
+
+    # Create scatter plot
+    fig = px.scatter(x=x, y=y, color=labels,
+                     labels={'x': xlabel, 'y': 'Frequency (kT)', 'color': 'Band'},
+                     title='Angular dependence of dHvA frequencies')
+    fig.update_layout(title_x=0.5)
+
+    return go.FigureWidget(fig)

--- a/src/aiidalab_qe_wannier90/setting.py
+++ b/src/aiidalab_qe_wannier90/setting.py
@@ -83,6 +83,24 @@ class ConfigurationSettingPanel(
             (self._model, 'plot_wannier_functions'),
             (self.plot_wannier_functions, 'value'),
         )
+        self.compute_fermi_surface = ipw.Checkbox(
+            value=self._model.compute_fermi_surface,
+            description='Compute Fermi surface',
+            style={'description_width': 'initial'},
+        )
+        ipw.link(
+            (self._model, 'compute_fermi_surface'),
+            (self.compute_fermi_surface, 'value'),
+        )
+        self.fermi_surface_kpoint_distance = ipw.FloatText(
+            value=self._model.fermi_surface_kpoint_distance,
+            description=r'Fermi surface k-point distance (Å$^{-1}$)',
+            style={'description_width': 'initial'},
+        )
+        ipw.link(
+            (self._model, 'fermi_surface_kpoint_distance'),
+            (self.fermi_surface_kpoint_distance, 'value'),
+        )
         self.number_of_disproj_max = ipw.IntText(
             value=self._model.number_of_disproj_max,
             description='Number of dis_proj_max',
@@ -217,6 +235,8 @@ class ConfigurationSettingPanel(
             self.exclude_semicore,
             self.plot_wannier_functions,
             self.retrieve_hamiltonian,
+            self.compute_fermi_surface,
+            self.fermi_surface_kpoint_distance,
             self.algorithm_description,
             self.projection_selection_widget,
             self.frozen_states_widget,

--- a/src/aiidalab_qe_wannier90/utils.py
+++ b/src/aiidalab_qe_wannier90/utils.py
@@ -63,3 +63,25 @@ def process_xsf_files(folder: str = 'parent_folder'):
     return {'atoms': atoms,
             'parameters': parameters,
             'mesh_data': mesh_data}
+
+def create_download_link(obj, filename, description='Download'):
+    """Create a download link for a file in the AiiDA repository using a temporary directory."""
+    import base64
+    import shutil
+    import tempfile
+    import ipywidgets as ipw
+    from pathlib import Path
+    # Create a temporary directory to store the file
+    # Copy the file from the AiiDA repository to the temporary directory
+    with obj.as_path(filename) as source_path:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir) / filename
+            shutil.copy(source_path, tmp_path)
+
+            with open(tmp_path, 'rb') as f:
+                b64 = base64.b64encode(f.read()).decode()
+
+    # At this point, we no longer need the file; it's encoded.
+    payload = f'data:application/octet-stream;base64,{b64}'
+    html = f'<a download="{filename}" href="{payload}" target="_blank">{description}</a>'
+    return ipw.HTML(html)

--- a/src/aiidalab_qe_wannier90/utils.py
+++ b/src/aiidalab_qe_wannier90/utils.py
@@ -63,25 +63,3 @@ def process_xsf_files(folder: str = 'parent_folder'):
     return {'atoms': atoms,
             'parameters': parameters,
             'mesh_data': mesh_data}
-
-def create_download_link(obj, filename, description='Download'):
-    """Create a download link for a file in the AiiDA repository using a temporary directory."""
-    import base64
-    import shutil
-    import tempfile
-    import ipywidgets as ipw
-    from pathlib import Path
-    # Create a temporary directory to store the file
-    # Copy the file from the AiiDA repository to the temporary directory
-    with obj.as_path(filename) as source_path:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmp_path = Path(tmpdir) / filename
-            shutil.copy(source_path, tmp_path)
-
-            with open(tmp_path, 'rb') as f:
-                b64 = base64.b64encode(f.read()).decode()
-
-    # At this point, we no longer need the file; it's encoded.
-    payload = f'data:application/octet-stream;base64,{b64}'
-    html = f'<a download="{filename}" href="{payload}" target="_blank">{description}</a>'
-    return ipw.HTML(html)

--- a/src/aiidalab_qe_wannier90/wannier90_workchain.py
+++ b/src/aiidalab_qe_wannier90/wannier90_workchain.py
@@ -65,8 +65,6 @@ class QeAppWannier90BandsWorkChain(WorkChain):
         protocol=None,
         parallelization=None,
         overrides=None,
-        compute_fermi_surface=False,
-        fermi_surface_kpoint_distance=None,
         **kwargs,
     ):
         """Return a BandsWorkChain builder prepopulated with inputs following the specified protocol

--- a/src/aiidalab_qe_wannier90/wannier90_workchain.py
+++ b/src/aiidalab_qe_wannier90/wannier90_workchain.py
@@ -4,6 +4,7 @@ from aiida.engine import WorkChain, if_
 from aiida_wannier90_workflows.workflows.bands import Wannier90BandsWorkChain
 from aiida_wannier90_workflows.workflows.optimize import Wannier90OptimizeWorkChain
 from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
+from aiida_skeaf.workflows import SkeafWorkChain
 from aiida_wannier90_workflows.utils.workflows.builder.setter import set_parallelization
 from aiida_pythonjob.launch import prepare_pythonjob_inputs
 from aiida_pythonjob import PythonJob
@@ -37,6 +38,14 @@ class QeAppWannier90BandsWorkChain(WorkChain):
                 'help': 'Outputs of the `Wannier90OptimizeWorkChain`.',
             },
         )
+        spec.expose_outputs(
+            SkeafWorkChain,
+            namespace='skeaf',
+            namespace_options={
+                'required': False,
+                'help': 'Outputs of the `SkeafWorkChain`.',
+            },
+        )
         spec.output_namespace('generate_isosurface', required=False, dynamic=True)
 
         spec.outline(cls.setup,
@@ -48,6 +57,10 @@ class QeAppWannier90BandsWorkChain(WorkChain):
                          cls.generate_isosurface,
                          cls.inspect_generate_isosurface
                      ),
+                     if_(cls.should_run_skeaf)(
+                         cls.run_skeaf,
+                         cls.inspect_skeaf
+                        ),
                      )
 
         spec.exit_code(
@@ -148,7 +161,7 @@ class QeAppWannier90BandsWorkChain(WorkChain):
         wannier90_parameters = overrides.pop('wannier90_parameters', {})
         number_of_disproj_max = wannier90_parameters.pop('number_of_disproj_max', 15)
         number_of_disproj_min = wannier90_parameters.pop('number_of_disproj_min', 2)
-        kwargs = self.inputs.kwargs if 'kwargs' in self.inputs else {}
+        kwargs_filtered = {k: v for k, v in self.inputs.kwargs.items() if k != 'compute_dhva_frequencies'}
         codes = {key: value for key, value in self.inputs.codes.items()}
         builder = Wannier90OptimizeWorkChain.get_builder_from_protocol(
             codes = codes,
@@ -157,7 +170,7 @@ class QeAppWannier90BandsWorkChain(WorkChain):
             reference_bands=reference_bands,
             bands_kpoints=bands_kpoints,
             overrides=overrides,
-            **kwargs,
+            **kwargs_filtered,
         )
         builder.optimize_disprojmax_range = orm.List(list=list(np.linspace(0.99, 0.85, number_of_disproj_max)))
         builder.optimize_disprojmin_range = orm.List(list=list(np.linspace(0.01, 0.15, number_of_disproj_min)))
@@ -221,3 +234,63 @@ class QeAppWannier90BandsWorkChain(WorkChain):
             self.out('generate_isosurface.parameters', workchain.outputs.parameters)
             self.out('generate_isosurface.mesh_data', workchain.outputs.mesh_data)
             self.report('Plot wf completed successfully')
+
+    def should_run_skeaf(self):
+        kwargs = self.inputs.kwargs if 'kwargs' in self.inputs else {}
+        return kwargs.get('compute_dhva_frequencies', False)
+
+    def run_skeaf(self):
+        """Run the `SkeafWorkChain` to compute the dHvA frequencies"""
+        from aiida_wannier90_workflows.utils.pseudo import get_number_of_electrons
+        if 'overrides' in self.inputs:
+            overrides = self.inputs.overrides.get('skeaf', {})
+        else:
+            overrides = {}
+        kwargs = self.inputs.kwargs if 'kwargs' in self.inputs else {}
+        wannier_node = self.ctx.wannier90_bands
+        wannier_calc = wannier_node.outputs.wannier90_optimal.output_parameters.creator
+        parent_folder = wannier_calc.outputs.remote_folder
+        pseudos = self.inputs.overrides.pw_bands['scf']['pw']['pseudos']
+        structure = wannier_calc.inputs.structure
+        num_excl_bands = wannier_calc.inputs.parameters.get('exclude_bands', [])
+        num_elec_pw = get_number_of_electrons(structure, pseudos)
+        num_electrons = num_elec_pw - 2 * len(num_excl_bands)
+        if abs(num_electrons - int(num_electrons)) > 1e-5:
+            raise ValueError('Non-integer number of electrons?')
+        num_electrons = int(num_electrons)
+
+        code_labels = ['wan2skeaf', 'skeaf']
+
+        codes = {label: self.inputs.codes[label] for label in code_labels}
+
+        builder = SkeafWorkChain.get_builder_from_protocol(
+        codes=codes,
+        bxsf=parent_folder,
+        num_electrons=num_electrons,
+        protocol=self.inputs.protocol.value,
+        )
+
+        skeaf_params = builder.skeaf.parameters.get_dict()
+        skeaf_params.update(
+            kwargs.get('dHvA_frequencies_parameters', {}),
+        )
+        builder.skeaf.parameters = orm.Dict(skeaf_params)
+
+        node = self.submit(builder)
+        self.report(f'submitting `WorkChain` <PK={node.pk}>')
+        self.to_context(**{'skeaf': node})
+
+    def inspect_skeaf(self):
+        """Attach the skeaf results"""
+        workchain = self.ctx['skeaf']
+
+        if not workchain.is_finished_ok:
+            self.report('SKEAF workchain failed')
+            return self.exit_codes.ERROR_WORKCHAIN_FAILED
+        else:
+            self.out_many(
+                self.exposed_outputs(
+                    self.ctx['skeaf'], SkeafWorkChain, namespace='skeaf'
+                )
+            )
+            self.report('SKEAF workchain completed successfully')

--- a/src/aiidalab_qe_wannier90/wannier90_workchain.py
+++ b/src/aiidalab_qe_wannier90/wannier90_workchain.py
@@ -65,6 +65,8 @@ class QeAppWannier90BandsWorkChain(WorkChain):
         protocol=None,
         parallelization=None,
         overrides=None,
+        compute_fermi_surface=False,
+        fermi_surface_kpoint_distance=None,
         **kwargs,
     ):
         """Return a BandsWorkChain builder prepopulated with inputs following the specified protocol

--- a/src/aiidalab_qe_wannier90/workchain.py
+++ b/src/aiidalab_qe_wannier90/workchain.py
@@ -22,16 +22,20 @@ def get_builder(codes, structure, parameters, **kwargs):
     projection_type=wannier90_parameters.pop('projection_type')
     frozen_type=wannier90_parameters.pop('frozen_type')
     compute_fermi_surface=wannier90_parameters.pop('compute_fermi_surface')
-    fermi_surface_kpoint_distance=wannier90_parameters.pop('fermi_surface_kpoint_distance')
+    fermi_surface_kpoint_distance=wannier90_parameters.pop('fermi_surface_kpoint_distance', False)
+    compute_dhva_frequencies=wannier90_parameters.pop('compute_dhva_frequencies', False)
 
     all_codes = {
                 'pw': codes.get('pw')['code'],
                 'pw2wannier90': codes.get('pw2wannier90')['code'],
                 'projwfc': codes.get('projwfc')['code'],
-                'wannier90': codes.get('wannier90')['code'],
+                'wannier90': codes.get('wannier90')['code']
             }
     if plot_wannier_functions:
         all_codes['python'] = codes.get('python')['code']
+    if compute_dhva_frequencies:
+        all_codes['skeaf'] = codes.get('skeaf')['code']
+        all_codes['wan2skeaf'] = codes.get('wan2skeaf')['code']
     check_codes(all_codes)
     protocol = parameters['workchain']['protocol']
     protocol_map = {
@@ -70,6 +74,7 @@ def get_builder(codes, structure, parameters, **kwargs):
         retrieve_matrices=retrieve_matrices,
         compute_fermi_surface=compute_fermi_surface,
         fermi_surface_kpoint_distance=fermi_surface_kpoint_distance,
+        compute_dhva_frequencies=compute_dhva_frequencies,
         **kwargs,
     )
     return builder

--- a/src/aiidalab_qe_wannier90/workchain.py
+++ b/src/aiidalab_qe_wannier90/workchain.py
@@ -21,6 +21,8 @@ def get_builder(codes, structure, parameters, **kwargs):
     retrieve_matrices=wannier90_parameters.pop('retrieve_matrices')
     projection_type=wannier90_parameters.pop('projection_type')
     frozen_type=wannier90_parameters.pop('frozen_type')
+    compute_fermi_surface=wannier90_parameters.pop('compute_fermi_surface')
+    fermi_surface_kpoint_distance=wannier90_parameters.pop('fermi_surface_kpoint_distance')
 
     all_codes = {
                 'pw': codes.get('pw')['code'],
@@ -66,6 +68,8 @@ def get_builder(codes, structure, parameters, **kwargs):
         frozen_type=WannierFrozenType(frozen_type),
         retrieve_hamiltonian=retrieve_hamiltonian,
         retrieve_matrices=retrieve_matrices,
+        compute_fermi_surface=compute_fermi_surface,
+        fermi_surface_kpoint_distance=fermi_surface_kpoint_distance,
         **kwargs,
     )
     return builder


### PR DESCRIPTION
* additional checkboxes and input fields to compute Fermi surface and dHvA frequencies
* `compute_fermi_surface` and `fermi_surface_kpoint_distance` keywords to the `get_builder_from_protocol` function of QeAppWannier90BandsWorkChain
* only add Fermi surface and dHvA related input parameters to the state if the respective checkboxes are activated
* add to the Results panel links to download some of the retrieved files
* plotting of dHvA frequencies with automated x-axis angle selection