### PR TITLE
Add option to disable pdwf loop

### DIFF
--- a/src/aiidalab_qe_wannier90/model.py
+++ b/src/aiidalab_qe_wannier90/model.py
@@ -15,6 +15,7 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
     # by default: exclude semicore orbitals in both methods, since these low-energy states correspond
     # to almost flat bands and do not play any role in the chemistry of the materials
     exclude_semicore = tl.Bool(allow_none=True, default_value=True)
+    scan_pdwf_parameter = tl.Bool(allow_none=True, default_value=False)
     plot_wannier_functions = tl.Bool(allow_none=True, default_value=False)
     number_of_disproj_max = tl.Int(allow_none=True, default_value=15)
     number_of_disproj_min = tl.Int(allow_none=True, default_value=2)

--- a/src/aiidalab_qe_wannier90/model.py
+++ b/src/aiidalab_qe_wannier90/model.py
@@ -49,6 +49,7 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
             'frozen_type': self.frozen_type,
             'energy_window_input': self.energy_window_input,
             'compute_fermi_surface': self.compute_fermi_surface,
+            'scan_pdwf_parameter': self.scan_pdwf_parameter,
         }
         if self.compute_fermi_surface:
             state |= {
@@ -78,3 +79,4 @@ class ConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
         self.dhva_starting_phi = parameters.get('dHvA_frequencies_parameters', {}).get('starting_phi', 0.0)
         self.dhva_starting_theta = parameters.get('dHvA_frequencies_parameters', {}).get('starting_theta', 90.0)
         self.dhva_num_rotation = parameters.get('dHvA_frequencies_parameters', {}).get('num_rotation', 90)
+        self.scan_pdwf_parameter = parameters.get('scan_pdwf_parameter', False)

--- a/src/aiidalab_qe_wannier90/result/result.py
+++ b/src/aiidalab_qe_wannier90/result/result.py
@@ -14,6 +14,7 @@ import numpy as np
 
 # Define a threshold for considering atoms "almost equally distant"
 DISTANCE_THRESHOLD = 0.01
+BAND_DISTANCE_WARNING_MEV = 10.0  # show warning if distance exceeds this threshold (in meV)
 
 ISOSURFACE_COLOR = {
     'positive': [1.0, 1.0, 0.0, 0.8],
@@ -31,10 +32,11 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         wannier90_bands['trace_settings'] = {'dash': 'dash',
                                              'shape': 'linear',
                                              'color': 'red'}
-        model = BandsPdosModel(bands = pw_bands,
-                               external_bands = {'Wannier-interpolated bands': wannier90_bands},
-                               plot_settings = {'bands_trace_settings': {'name': 'DFT Bands'}},
-                            )
+        model = BandsPdosModel(
+            bands=pw_bands,
+            external_bands={'Wannier-interpolated bands': wannier90_bands},
+            plot_settings={'bands_trace_settings': {'name': 'DFT bands'}},
+        )
 
         # Create and render the bands/PDOS widget
         bands_widget = BandsPdosWidget(model=model)
@@ -43,40 +45,68 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         # Wannier90 outputs summary (merged with bands distance)
         wannier90_outputs = self._model.wannier90_outputs
         bands_distance = self._model.bands_distance
-        omega_tot = wannier90_outputs['Omega_D'] + wannier90_outputs['Omega_I'] + wannier90_outputs['Omega_OD']
+        omega_tot = (
+            wannier90_outputs['Omega_D']
+            + wannier90_outputs['Omega_I']
+            + wannier90_outputs['Omega_OD']
+        )
+
+        # Yellow warning if bands distance > 10 meV
+        bands_distance_warning_widget = ipw.HTML()
+        bands_distance_mev = bands_distance * 1000.0
 
         wannier90_outputs_parameters = ipw.HTML(
             f"""
             <div style="margin-top:10px; padding:15px;">
             <table style="width:60%; border-collapse:collapse; text-align:left; font-size:14px;">
                 <tr>
-                <td><b>Number of WFs:</b></td>
-                <td>{wannier90_outputs['number_wfs']}</td>
+                    <td><b>Number of WFs:</b></td>
+                    <td>{wannier90_outputs['number_wfs']}</td>
                 </tr>
                 <tr>
-                <td><b>Total spread Ω<sub>tot</sub>:</b></td>
-                <td>{omega_tot:.3f} Å²</td>
+                    <td><b>Total spread Ω<sub>tot</sub>:</b></td>
+                    <td>{omega_tot:.3f} Å²</td>
                 </tr>
-
                 <tr>
-                <td><b>Components of the spread:</b></td>
-                <td>Ω<sub>D</sub>: {wannier90_outputs['Omega_D']:.3f} Å² &nbsp;&nbsp;
-                    Ω<sub>I</sub>: {wannier90_outputs['Omega_I']:.3f} Å² &nbsp;&nbsp;
-                    Ω<sub>OD</sub>: {wannier90_outputs['Omega_OD']:.3f} Å²
-                </td>
+                    <td><b>Components of the spread:</b></td>
+                    <td>
+                        Ω<sub>D</sub>: {wannier90_outputs['Omega_D']:.3f} Å² &nbsp;&nbsp;
+                        Ω<sub>I</sub>: {wannier90_outputs['Omega_I']:.3f} Å² &nbsp;&nbsp;
+                        Ω<sub>OD</sub>: {wannier90_outputs['Omega_OD']:.3f} Å²
+                    </td>
                 </tr>
-
                 <tr>
-                <td><b>Band Distance:</b></td>
-                <td>{bands_distance * 1000:.3f} meV</td>
+                    <td><b>Band distance:</b></td>
+                    <td>{bands_distance_mev:.3f} meV</td>
                 </tr>
             </table>
             </div>
             """
         )
+        show_bands_distance_warning = False
+        if bands_distance_mev > BAND_DISTANCE_WARNING_MEV:
+            show_bands_distance_warning = True
+            bands_distance_warning_widget.value = f"""
+            <div style="
+                margin: 12px 0;
+                padding: 12px 14px;
+                border: 1px solid #f1c40f;
+                background: #fff8db;
+                color: #7a5f00;
+                border-radius: 8px;
+                font-size: 14px;
+                line-height: 1.4;
+            ">
+                <strong>Warning:</strong>
+                Current bands distance: {bands_distance_mev:.3f} meV > 10 meV.
+                Considering rerunning this workflow by activating
+                <em>Exhaustive PDWF parameters scan</em>, in the
+                settings panel of the Wannier90 plugin (step 2), if you have not already done so.
+                <br>
+            </div>
+            """
 
-
-        # Omega convergence plot
+        # Omega convergence plots
         omega_is = self._model.omega_is
         fig = px.line(
             x=range(len(omega_is)), y=omega_is,
@@ -85,7 +115,7 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         fig.update_yaxes(title='Ωᵢ')
         fig.update_xaxes(title='Number of iterations')
         self.plot_omega_is = go.FigureWidget(fig)
-        #
+
         omega_tots = self._model.omega_tots
         fig = px.line(
             x=range(len(omega_tots)), y=omega_tots,
@@ -95,45 +125,45 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         fig.update_xaxes(title='Number of iterations')
         self.plot_omega_tots = go.FigureWidget(fig)
 
-        # structure
+        # Structure
         self.structure_viewer = WeasWidget()
         atoms = self._model.structure.get_ase()
         self.structure_viewer.from_ase(atoms)
         self.structure_viewer.avr.model_style = 1
         self.structure_viewer.avr.color_type = 'VESTA'
         self.structure_viewer.avr.boundary = [[-0.05, 1.05], [-0.05, 1.05], [-0.05, 1.05]]
-        # isosurface
-        self.isosurface_data = self._model.get_isosurface()
+
+        # Isosurface
+        self.isosurface_data = self._model.get_isosurface() or {'parameters': {}, 'mesh_data': {}}
 
         structure_viewer_section = ipw.VBox([
             ipw.HTML('<h3>Structure</h3>'),
             self.structure_viewer,
-        ], layout=ipw.Layout(width='50%',
-            margin='10px 0'))
+        ], layout=ipw.Layout(width='50%', margin='10px 0'))
 
-        # Wannier centers/spreads table
+        # Wannier centers and spreads table
         self.table = TableWidget(style={'margin-top': '10px'})
         self.table.from_data(
             self._model.wannier_centers_spreads['data'],
             columns=self._model.wannier_centers_spreads['columns']
         )
-
         self.table.observe(self.on_single_row_select, 'selectedRowId')
-        self.table_description = ipw.HTML('Click on a table row to visualize on the right the corresponding Wannier function in real space.')
+        self.table_description = ipw.HTML(
+            'Click on a table row to visualize on the right the corresponding Wannier function in real space.'
+        )
         table_section = ipw.VBox([
-            ipw.HTML('<h3>Wannier centers/spreads</h3>'),
+            ipw.HTML('<h3>Wannier centers and spreads</h3>'),
             self.table_description,
             self.table
-        ], layout=ipw.Layout(width='50%',
-            margin='10px 0'))
+        ], layout=ipw.Layout(width='50%', margin='10px 0'))
 
         self.skeaf_container = ipw.VBox([
-                ipw.HTML('<h2>Fermi surface</h2>'),
-                ipw.HTML('<h3>de Haas van Alphen (dHva) frequencies</h3>'),
-            ])
+            ipw.HTML('<h2>Fermi surface</h2>'),
+            ipw.HTML('<h3>de Haas van Alphen (dHva) frequencies</h3>'),
+        ])
 
         # de Haas van Alphen (dHvA) frequencies
-        skeaf_data = self._model.get_skeaf() # skeaf_data is a dictionary {band: frequency_array}
+        skeaf_data = self._model.get_skeaf()  # dictionary {band: frequency_array}
         if skeaf_data is not None:
             self.plot_skeaf = plot_skeaf(skeaf_data)
             self.skeaf_container.children += (self.plot_skeaf,)
@@ -143,19 +173,17 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
 
         # Downloads section
         download_links = []
-
         for filename in self._model.retrieved.list_object_names():
             if filename.endswith('_tb.dat'):
-                # Create a download link for the .tb.dat file
                 temp_dir = self._model.retrieved
                 download_links.append(create_download_link(
-                    temp_dir, filename, description=f'Download the tight-binding model {filename}'))
+                    temp_dir, filename, description=f'Download the tight-binding model {filename}'
+                ))
             elif filename.endswith('.bxsf'):
-                # Create a download link for the .bxsf file
                 temp_dir = self._model.retrieved
                 download_links.append(create_download_link(
-                    temp_dir, filename, description=f'Download the Fermi surface {filename}'))
-
+                    temp_dir, filename, description=f'Download the Fermi surface {filename}'
+                ))
 
         # Arrange components in the panel
         self.children = [
@@ -166,6 +194,7 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
             ipw.VBox([
                 ipw.HTML('<h2>Wannierization details</h2>'),
                 wannier90_outputs_parameters,
+                bands_distance_warning_widget if show_bands_distance_warning else ipw.HTML(''),
                 ipw.HBox([self.plot_omega_is, self.plot_omega_tots]),
                 ipw.HBox([structure_viewer_section, table_section]),
             ]),
@@ -177,29 +206,49 @@ class Wannier90ResultsPanel(ResultsPanel[Wannier90ResultsModel]):
         ]
 
     def on_single_row_select(self, change):
-        id = change['new']
-        center = [row['centers_final'] for row in self.table.data if row['id'] == id][0]
-        center = ast.literal_eval(center)
+        id = change.get('new')
+        if id is None:
+            return
+
+        # Get center for the selected row
+        try:
+            center_str = next(row['centers_final'] for row in self.table.data if row['id'] == id)
+            center = ast.literal_eval(center_str)
+        except StopIteration:
+            return
+        except Exception:
+            # Fallback if parsing fails
+            return
+
         atoms = self._model.structure.get_ase()
         positions = atoms.get_positions()
         distances = np.linalg.norm(positions - center, axis=1)
-        # Find minimum distance
-        min_distance = np.min(distances)
-        # Find all atoms that are within the threshold of the minimum distance
+
+        # Find minimum distance and atoms within threshold
+        min_distance = float(np.min(distances))
         indices = np.where(np.abs(distances - min_distance) < DISTANCE_THRESHOLD)[0]
         self.structure_viewer.avr.selected_atoms_indices = indices.tolist()
+
         key = f'aiida_{int(id):05d}'
         data = []
-        if 'isovalue' in self.isosurface_data['parameters'][key]:
+
+        params = self.isosurface_data.get('parameters', {})
+        mesh = self.isosurface_data.get('mesh_data', {})
+
+        if key in params and 'isovalue' in params[key]:
             for item in ['positive', 'negative']:
-                vertices = self.isosurface_data['mesh_data'][f'{key}_{item}_vertices'].value.tolist()
-                faces = self.isosurface_data['mesh_data'][f'{key}_{item}_faces'].value.tolist()
+                try:
+                    vertices = mesh[f'{key}_{item}_vertices'].value.tolist()
+                    faces = mesh[f'{key}_{item}_faces'].value.tolist()
+                except KeyError:
+                    continue
                 data.append({
-                        'name': item,
-                        'color': ISOSURFACE_COLOR[item],
-                        'material': 'Standard',
-                        'position': [0, 0.0, 0.0],
-                        'vertices': vertices,
-                        'faces': faces,
-                    })
+                    'name': item,
+                    'color': ISOSURFACE_COLOR[item],
+                    'material': 'Standard',
+                    'position': [0, 0.0, 0.0],
+                    'vertices': vertices,
+                    'faces': faces,
+                })
+
         self.structure_viewer.any_mesh.settings = data

--- a/src/aiidalab_qe_wannier90/setting.py
+++ b/src/aiidalab_qe_wannier90/setting.py
@@ -87,6 +87,18 @@ class ConfigurationSettingPanel(
             (self._model, 'retrieve_matrices'),
             (self.retrieve_matrices, 'value'),
         )
+        self.scan_pdwf_parameter = ipw.Checkbox(
+            value=self._model.scan_pdwf_parameter,
+            description='Exhaustive PDWF parameter scan',
+            style={'description_width': 'initial'},
+            tooltip='If enabled, an exhaustive scan of the PDWF thresholds is ' \
+            'performed (up to 30 Wannierizations) to find those that bring the ' \
+            'bands distance (for bands up to 2 eV above the Fermi level) below 10 meV.',
+        )
+        ipw.link(
+            (self._model, 'scan_pdwf_parameter'),
+            (self.scan_pdwf_parameter, 'value'),
+        )
         self.plot_wannier_functions = ipw.Checkbox(
             value=self._model.plot_wannier_functions,
             description='Compute real-space Wannier functions',

--- a/src/aiidalab_qe_wannier90/setting.py
+++ b/src/aiidalab_qe_wannier90/setting.py
@@ -341,8 +341,7 @@ class ConfigurationSettingPanel(
             self.algorithm_description,
             self.projection_selection_widget,
             self.frozen_states_widget,
-            # self.number_of_disproj_max,
-            # self.number_of_disproj_min,
+            self.scan_pdwf_parameter,
         ]
         self.rendered = True
 

--- a/src/aiidalab_qe_wannier90/wannier90_workchain.py
+++ b/src/aiidalab_qe_wannier90/wannier90_workchain.py
@@ -159,9 +159,14 @@ class QeAppWannier90BandsWorkChain(WorkChain):
         else:
             overrides = {}
         wannier90_parameters = overrides.pop('wannier90_parameters', {})
-        number_of_disproj_max = wannier90_parameters.pop('number_of_disproj_max', 15)
-        number_of_disproj_min = wannier90_parameters.pop('number_of_disproj_min', 2)
-        kwargs_filtered = {k: v for k, v in self.inputs.kwargs.items() if k not in ['compute_dhva_frequencies','dHvA_frequencies_parameters']}
+        scan_pdwf_parameter = wannier90_parameters.pop('scan_pdwf_parameter', False)
+        if scan_pdwf_parameter:
+            number_of_disproj_max = 2
+            number_of_disproj_min = 2
+        else:
+            number_of_disproj_max = 1
+            number_of_disproj_min = 1
+        kwargs_filtered = {k: v for k, v in self.inputs.kwargs.items() if k not in ['compute_fermi_surface', 'fermi_surface_kpoint_distance', 'compute_dhva_frequencies','dHvA_frequencies_parameters']}
         codes = {key: value for key, value in self.inputs.codes.items()}
         builder = Wannier90OptimizeWorkChain.get_builder_from_protocol(
             codes = codes,


### PR DESCRIPTION

Loop of PDWF parameters in workflows, in the setting panel, adds a checkbox (false by default): "Exhaustive PDWF parameters scan".
In tooltip: " If enabled, an exhaustive scan of the PDWF thresholds is performed (up to 30 Wannierizations) to find those that bring the bands distance (for bands up to 2 eV above the Fermi level) below 10 meV"

In the results panel: if the band distance is greater than 10 meV, show a yellow warning: "Considering rerunning this workflow by activating, in the ..."

Set the numbers to 1 if the scan is not activated.
```python
            number_of_disproj_max = 1
            number_of_disproj_min = 1
```